### PR TITLE
Feature: 버전 공통 페이지 응답 및 서브트리 DB저장 기능 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,5 +24,6 @@ module.exports = {
     semi: "warn",
     "no-unused-vars": "warn",
     "no-param-reassign": 0,
+    "no-restricted-syntax": ["error", "LabeledStatement", "WithStatement"],
   },
 };

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,0 +1,9 @@
+require("dotenv").config();
+
+const CONSTANTS = {
+  NO_PREVIOUS_VERSIONS: 2,
+  PAGE_NODE_DEPTH: 1,
+  FRAME_NODE_DEPTH: 2,
+};
+
+module.exports = CONSTANTS;

--- a/src/constants/error.js
+++ b/src/constants/error.js
@@ -9,7 +9,7 @@ const ERROR_PATTERNS = {
   },
   BAD_REQUEST: {
     status: 400,
-    message: "Bad Request: 잘못된 요청입니다. ",
+    message: "Bad Request: 잘못된 요청입니다.",
   },
   SERVER_ERROR: {
     status: 500,

--- a/src/constants/error.js
+++ b/src/constants/error.js
@@ -1,0 +1,20 @@
+const ERROR_PATTERNS = {
+  UNAUTHORIZED: {
+    status: 401,
+    message: "Unauthorized: 유효한 인증 정보가 아닙니다.",
+  },
+  NOT_FOUND: {
+    status: 404,
+    message: "Not Found: 요청한 페이지를 찾을 수 없습니다.",
+  },
+  BAD_REQUEST: {
+    status: 400,
+    message: "Bad Request: 잘못된 요청입니다. ",
+  },
+  SERVER_ERROR: {
+    status: 500,
+    message: "Internal Server Error: 서버 통신이 원활하지 않습니다.",
+  },
+};
+
+module.exports = ERROR_PATTERNS;

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -15,7 +15,7 @@ const getAllVersions = async (req, res, next) => {
       {
         method: "GET",
         headers: {
-          "X-FIGMA_TOKEN": accessToken,
+          Authorization: `Bearer ${accessToken}`,
         },
       },
     );
@@ -47,7 +47,7 @@ const getCommonPages = async (req, res, next) => {
     const responseJson = await fetch(figmaUrl, {
       method: "GET",
       headers: {
-        "X-FIGMA-TOKEN": accessToken,
+        Authorization: `Bearer ${accessToken}`,
       },
     });
     const data = await responseJson.json();

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -1,9 +1,11 @@
 /* eslint-disable consistent-return */
+const createHttpError = require("http-errors");
 const Document = require("../models/Document");
 
 const comparePages = require("../utils/comparePages");
 const saveFigmaDataAsNestedStructure = require("../utils/saveFigmaDataAsNestedStructure");
 const CONSTANT = require("../constants/constants");
+const ERROR_MESSAGE = require("../constants/error");
 
 const getAllVersions = async (req, res, next) => {
   const { projectId } = req.params;
@@ -24,14 +26,21 @@ const getAllVersions = async (req, res, next) => {
     const { versions } = responseJson;
 
     if (versions.length < CONSTANT.NO_PREVIOUS_VERSIONS) {
-      return res.status(502).send({
-        error: "해당 파일은 비교할 수 있는 버전이 없어요.",
+      return res.json({
+        result: "error",
+        status: 502,
+        message: "해당 파일은 비교할 수 있는 버전이 없어요.",
       });
     }
 
     res.status(200).json(responseJson);
   } catch (err) {
-    next(err);
+    const customError = createHttpError(
+      ERROR_MESSAGE.SERVER_ERROR.status,
+      ERROR_MESSAGE.SERVER_ERROR.message,
+    );
+
+    next(customError);
   }
 };
 
@@ -50,9 +59,9 @@ const getCommonPages = async (req, res, next) => {
         Authorization: `Bearer ${accessToken}`,
       },
     });
-    const data = await responseJson.json();
+    const projectVersionSubtree = await responseJson.json();
 
-    return data;
+    return projectVersionSubtree;
   };
 
   const getDocument = async (projectKey, versionId) => {
@@ -96,7 +105,12 @@ const getCommonPages = async (req, res, next) => {
 
     res.status(200).json(matchedPages);
   } catch (err) {
-    next(err);
+    const customError = createHttpError(
+      ERROR_MESSAGE.SERVER_ERROR.status,
+      ERROR_MESSAGE.SERVER_ERROR.message,
+    );
+
+    next(customError);
   }
 };
 

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -5,7 +5,7 @@ const Document = require("../models/Document");
 const comparePages = require("../utils/comparePages");
 const saveFigmaDataAsNestedStructure = require("../utils/saveFigmaDataAsNestedStructure");
 const CONSTANT = require("../constants/constants");
-const ERROR_MESSAGE = require("../constants/error");
+const ERROR = require("../constants/error");
 
 const getAllVersions = async (req, res, next) => {
   const { projectId } = req.params;
@@ -36,8 +36,8 @@ const getAllVersions = async (req, res, next) => {
     res.status(200).json(responseJson);
   } catch (err) {
     const customError = createHttpError(
-      ERROR_MESSAGE.SERVER_ERROR.status,
-      ERROR_MESSAGE.SERVER_ERROR.message,
+      ERROR.SERVER_ERROR.status,
+      ERROR.SERVER_ERROR.message,
     );
 
     next(customError);
@@ -106,8 +106,8 @@ const getCommonPages = async (req, res, next) => {
     res.status(200).json(matchedPages);
   } catch (err) {
     const customError = createHttpError(
-      ERROR_MESSAGE.SERVER_ERROR.status,
-      ERROR_MESSAGE.SERVER_ERROR.message,
+      ERROR.SERVER_ERROR.status,
+      ERROR.SERVER_ERROR.message,
     );
 
     next(customError);

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -1,3 +1,4 @@
+/* eslint-disable consistent-return */
 const Document = require("../models/Document");
 
 const comparePages = require("../utils/comparePages");
@@ -28,11 +29,9 @@ const getAllVersions = async (req, res, next) => {
       });
     }
 
-    return res.status(200).json(responseJson);
+    res.status(200).json(responseJson);
   } catch (err) {
     next(err);
-
-    return undefined;
   }
 };
 
@@ -95,11 +94,9 @@ const getCommonPages = async (req, res, next) => {
       afterDocument.pages,
     );
 
-    return res.status(200).json(matchedPages);
+    res.status(200).json(matchedPages);
   } catch (err) {
     next(err);
-
-    return undefined;
   }
 };
 

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -1,0 +1,151 @@
+const Document = require("../models/Document");
+
+const comparePages = require("../utils/comparePages");
+const saveFigmaDataAsNestedStructure = require("../utils/saveFigmaDataAsNestedStructure");
+
+exports.getAllVersions = async function (req, res) {
+  const { projectId } = req.params;
+  const accessToken = req.headers.authorization;
+
+  try {
+    const getVersions = await fetch(
+      `https://api.figma.com/v1/files/${projectId}/versions`,
+      {
+        method: "GET",
+        headers: {
+          "X-FIGMA-TOKEN": accessToken,
+        },
+      },
+    );
+
+    const responseJson = await getVersions.json();
+    const { status, versions } = responseJson;
+
+    if (status === 400) {
+      return res.status(400).send({
+        result: "error",
+        error: {
+          message: "잘못된 사용자 요청입니다. Figma Token을 확인해주세요.",
+        },
+      });
+    }
+
+    if (status === 403) {
+      return res.status(403).send({
+        result: "error",
+        error: {
+          message: "인증되지 않은 사용자입니다.",
+        },
+      });
+    }
+
+    if (status === 404) {
+      return res.status(404).send({
+        result: "error",
+        error: {
+          message: "존재하지 않는 피그마 파일입니다. 다시 입력해주세요.",
+        },
+      });
+    }
+
+    if (status === 500) {
+      return res.status(500).send({
+        result: "error",
+        error: {
+          message: "프로젝트 용량이 너무 커 응답에 실패했습니다.",
+        },
+      });
+    }
+
+    if (versions.length < 2) {
+      return res.status(502).send({
+        result: "error",
+        error: {
+          message: "비교할 수 있는 버전이 없어서 서비스 이용이 불가합니다.",
+        },
+      });
+    }
+
+    return res.status(200).json(responseJson);
+  } catch (err) {
+    return res.status(500).send({
+      result: "error",
+      error: {
+        message: "피그마 API로부터 응답이 없습니다.",
+      },
+    });
+  }
+};
+
+exports.getCommonPages = async function (req, res) {
+  const { projectId } = req.params;
+  const accessToken = req.headers.authorization;
+  const beforeVersion = req.query["before-version"];
+  const afterVersion = req.query["after-version"];
+
+  async function fetchFigmaData(projectKey, versionId) {
+    const figmaUrl = `https://api.figma.com/v1/files/${projectKey}?version=${versionId}`;
+
+    const responseJson = await fetch(figmaUrl, {
+      method: "GET",
+      headers: {
+        "X-FIGMA-TOKEN": accessToken,
+      },
+    });
+    const data = await responseJson.json();
+
+    return data;
+  }
+
+  async function getDocument(projectKey, versionId) {
+    const document = await Document.findOne({
+      projectKey,
+      versionId,
+    });
+
+    return document;
+  }
+
+  async function createDocument(projectKey, versionId) {
+    const figmaData = await fetchFigmaData(projectKey, versionId);
+    let document = await saveFigmaDataAsNestedStructure(
+      figmaData.document,
+      null,
+      0,
+    );
+
+    document.projectKey = projectKey;
+    document.versionId = versionId;
+
+    document = await Document.create(document);
+
+    return document;
+  }
+
+  try {
+    let beforeDocument = await getDocument(projectId, beforeVersion);
+    let afterDocument = await getDocument(projectId, afterVersion);
+
+    if (!beforeDocument) {
+      beforeDocument = await createDocument(projectId, beforeVersion);
+    }
+
+    if (!afterDocument) {
+      afterDocument = await createDocument(projectId, afterVersion);
+    }
+
+    const matchedPages = comparePages(
+      beforeDocument.pages,
+      afterDocument.pages,
+    );
+
+    return res.status(200).json(matchedPages);
+  } catch (err) {
+    return res.status(500).send({
+      result: "error",
+      error: {
+        message: "피그마 API로부터 응답이 없습니다.",
+      },
+    });
+  }
+};

--- a/src/loaders/error.js
+++ b/src/loaders/error.js
@@ -1,6 +1,6 @@
 const createError = require("http-errors");
 
-const errorHandlerLoader = (app) => {
+const errorLoader = (app) => {
   app.use((req, res, next) => {
     next(createError(404));
   });
@@ -10,8 +10,8 @@ const errorHandlerLoader = (app) => {
     res.locals.error = req.app.get("env") === "development" ? err : {};
 
     res.status(err.status || 500);
-    res.json({ message: err.message });
+    res.json({ result: "error", status: err.status, message: err.message });
   });
 };
 
-module.exports = errorHandlerLoader;
+module.exports = errorLoader;

--- a/src/loaders/errorHandler.js
+++ b/src/loaders/errorHandler.js
@@ -1,0 +1,17 @@
+const createError = require("http-errors");
+
+const errorHandlerLoader = (app) => {
+  app.use((req, res, next) => {
+    next(createError(404));
+  });
+
+  app.use((err, req, res) => {
+    res.locals.message = err.message;
+    res.locals.error = req.app.get("env") === "development" ? err : {};
+
+    res.status(err.status || 500);
+    res.json({ message: err.message });
+  });
+};
+
+module.exports = errorHandlerLoader;

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -1,13 +1,13 @@
 const mongooseLoader = require("./mongoose");
 const expressLoader = require("./express");
 const routerLoader = require("./routers");
-const errorHandlerLoader = require("./errorHandler");
+const errorLoader = require("./error");
 
 const appLoader = async (app) => {
   await mongooseLoader();
   await expressLoader(app);
   await routerLoader(app);
-  await errorHandlerLoader(app);
+  await errorLoader(app);
 };
 
 module.exports = appLoader;

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -1,11 +1,13 @@
 const mongooseLoader = require("./mongoose");
 const expressLoader = require("./express");
 const routerLoader = require("./routers");
+const errorHandlerLoader = require("./errorHandler");
 
 const appLoader = async (app) => {
   await mongooseLoader();
   await expressLoader(app);
   await routerLoader(app);
+  await errorHandlerLoader(app);
 };
 
 module.exports = appLoader;

--- a/src/models/Document.js
+++ b/src/models/Document.js
@@ -11,18 +11,19 @@ const NodeSchema = new Schema({
 
 const FrameSchema = new Schema({
   frameId: { type: String, require: true },
+  name: { type: String, require: true },
   nodes: [NodeSchema],
 });
 
 const PageSchema = new Schema({
   pageId: { type: String, require: true },
+  name: { type: String, require: true },
   frames: [FrameSchema],
 });
 
 const DocumentSchema = new Schema({
   projectKey: { type: String, require: true },
   versionId: { type: String, require: true },
-  name: { type: String, require: true },
   pages: [PageSchema],
 });
 

--- a/src/routers/projects.js
+++ b/src/routers/projects.js
@@ -1,83 +1,14 @@
 const express = require("express");
 
+const projectController = require("../controllers/projectController");
+
 const router = express.Router();
 
-router.get("/", function (req, res) {
-  res.status(200).send({ sucess: true });
+router.get("/", (req, res) => {
+  res.status(200).send({ success: true });
 });
 
-router.get("/:projectId/versions", async (req, res) => {
-  const { projectId } = req.params;
-  const accessToken = req.headers.authorization;
-
-  try {
-    const getVersions = await fetch(
-      `https://api.figma.com/v1/files/${projectId}/versions`,
-      {
-        method: "GET",
-        headers: {
-          "X-FIGMA-TOKEN": accessToken,
-        },
-      },
-    );
-
-    const responseJson = await getVersions.json();
-    const { status, versions } = responseJson;
-
-    if (status === 400) {
-      return res.status(400).send({
-        result: "error",
-        error: {
-          message: "잘못된 사용자 요청입니다. Figma Token을 확인해주세요.",
-        },
-      });
-    }
-
-    if (status === 403) {
-      return res.status(403).send({
-        result: "error",
-        error: {
-          message: "인증되지 않은 사용자입니다.",
-        },
-      });
-    }
-
-    if (status === 404) {
-      return res.status(404).send({
-        result: "error",
-        error: {
-          message: "존재하지 않는 피그마 파일입니다. 다시 입력해주세요.",
-        },
-      });
-    }
-
-    if (status === 500) {
-      return res.status(500).send({
-        result: "error",
-        error: {
-          message: "프로젝트 용량이 너무 커 응답에 실패했습니다.",
-        },
-      });
-    }
-
-    if (versions.length < 2) {
-      return res.status(502).send({
-        result: "error",
-        error: {
-          message: "비교할 수 있는 버전이 없어서 서비스 이용이 불가합니다.",
-        },
-      });
-    }
-
-    return res.status(200).json(responseJson);
-  } catch (err) {
-    return res.status(500).send({
-      result: "error",
-      error: {
-        message: "피그마 API로부터 응답이 없습니다.",
-      },
-    });
-  }
-});
+router.get("/:projectId/versions", projectController.getAllVersions);
+router.get("/:projectId/pages", projectController.getCommonPages);
 
 module.exports = router;

--- a/src/routers/projects.js
+++ b/src/routers/projects.js
@@ -4,10 +4,6 @@ const projectController = require("../controllers/projectController");
 
 const router = express.Router();
 
-router.get("/", (req, res) => {
-  res.status(200).send({ success: true });
-});
-
 router.get("/:projectId/versions", projectController.getAllVersions);
 router.get("/:projectId/pages", projectController.getCommonPages);
 

--- a/src/utils/comparePages.js
+++ b/src/utils/comparePages.js
@@ -1,0 +1,17 @@
+function comparePages(beforePages, afterPages) {
+  const matchedPages = [];
+
+  beforePages.forEach((beforePage) => {
+    const matchedPage = afterPages.find(
+      (afterPage) => afterPage.pageId === beforePage.pageId,
+    );
+
+    if (matchedPage) {
+      matchedPages.push(matchedPage);
+    }
+  });
+
+  return matchedPages;
+}
+
+module.exports = comparePages;

--- a/src/utils/saveFigmaDataAsNestedStructure.js
+++ b/src/utils/saveFigmaDataAsNestedStructure.js
@@ -1,12 +1,12 @@
-const PAGE_UNIT_DEPTH = 1;
-const FRAME_UNIT_DEPTH = 2;
+const PAGE_NODE_DEPTH = 1;
+const FRAME_NODE_DEPTH = 2;
 
-async function saveFigmaDataAsNestedStructure(
+const saveFigmaDataAsNestedStructure = async (
   node,
   parent = null,
   depth = 0,
   currentFrameId = "",
-) {
+) => {
   if (depth === 0 && node.type === "DOCUMENT") {
     parent = { pages: [] };
   }
@@ -17,7 +17,7 @@ async function saveFigmaDataAsNestedStructure(
     });
   }
 
-  if (node.type === "CANVAS" && depth === PAGE_UNIT_DEPTH) {
+  if (node.type === "CANVAS" && depth === PAGE_NODE_DEPTH) {
     const newPage = { pageId: node.id, name: node.name, frames: [] };
 
     if (parent.pages) {
@@ -27,7 +27,7 @@ async function saveFigmaDataAsNestedStructure(
     node.children.forEach((child) =>
       saveFigmaDataAsNestedStructure(child, newPage, depth + 1),
     );
-  } else if (node.type === "FRAME" && depth === FRAME_UNIT_DEPTH) {
+  } else if (node.type === "FRAME" && depth === FRAME_NODE_DEPTH) {
     const newFrame = { frameId: node.id, name: node.name, nodes: [] };
 
     if (parent.frames) {
@@ -37,7 +37,7 @@ async function saveFigmaDataAsNestedStructure(
     node.children.forEach((child) =>
       saveFigmaDataAsNestedStructure(child, newFrame, depth + 1),
     );
-  } else if (depth > FRAME_UNIT_DEPTH) {
+  } else if (depth > FRAME_NODE_DEPTH) {
     const newNode = {
       nodeId: node.id,
       type: node.type,
@@ -54,11 +54,13 @@ async function saveFigmaDataAsNestedStructure(
       "children",
     ];
 
-    Object.keys(node).forEach((key) => {
-      if (!excludedKeys.includes(key)) {
-        newNode.property[key] = node[key];
+    for (const key in node) {
+      if (Object.prototype.hasOwnProperty.call(node, key)) {
+        if (!excludedKeys.includes(key)) {
+          newNode.property[key] = node[key];
+        }
       }
-    });
+    }
 
     if (parent.nodes) {
       parent.nodes.push(newNode);
@@ -66,6 +68,6 @@ async function saveFigmaDataAsNestedStructure(
   }
 
   return parent;
-}
+};
 
 module.exports = saveFigmaDataAsNestedStructure;

--- a/src/utils/saveFigmaDataAsNestedStructure.js
+++ b/src/utils/saveFigmaDataAsNestedStructure.js
@@ -1,5 +1,4 @@
-const PAGE_NODE_DEPTH = 1;
-const FRAME_NODE_DEPTH = 2;
+const CONSTANT = require("../constants/constants");
 
 const saveFigmaDataAsNestedStructure = async (
   node,
@@ -17,7 +16,7 @@ const saveFigmaDataAsNestedStructure = async (
     });
   }
 
-  if (node.type === "CANVAS" && depth === PAGE_NODE_DEPTH) {
+  if (node.type === "CANVAS" && depth === CONSTANT.PAGE_NODE_DEPTH) {
     const newPage = { pageId: node.id, name: node.name, frames: [] };
 
     if (parent.pages) {
@@ -27,7 +26,7 @@ const saveFigmaDataAsNestedStructure = async (
     node.children.forEach((child) =>
       saveFigmaDataAsNestedStructure(child, newPage, depth + 1),
     );
-  } else if (node.type === "FRAME" && depth === FRAME_NODE_DEPTH) {
+  } else if (node.type === "FRAME" && depth === CONSTANT.FRAME_NODE_DEPTH) {
     const newFrame = { frameId: node.id, name: node.name, nodes: [] };
 
     if (parent.frames) {
@@ -37,7 +36,7 @@ const saveFigmaDataAsNestedStructure = async (
     node.children.forEach((child) =>
       saveFigmaDataAsNestedStructure(child, newFrame, depth + 1),
     );
-  } else if (depth > FRAME_NODE_DEPTH) {
+  } else if (depth > CONSTANT.FRAME_NODE_DEPTH) {
     const newNode = {
       nodeId: node.id,
       type: node.type,

--- a/src/utils/saveFigmaDataAsNestedStructure.js
+++ b/src/utils/saveFigmaDataAsNestedStructure.js
@@ -1,0 +1,71 @@
+const PAGE_UNIT_DEPTH = 1;
+const FRAME_UNIT_DEPTH = 2;
+
+async function saveFigmaDataAsNestedStructure(
+  node,
+  parent = null,
+  depth = 0,
+  currentFrameId = "",
+) {
+  if (depth === 0 && node.type === "DOCUMENT") {
+    parent = { pages: [] };
+  }
+
+  if (node.children) {
+    node.children.forEach((child) => {
+      saveFigmaDataAsNestedStructure(child, parent, depth + 1);
+    });
+  }
+
+  if (node.type === "CANVAS" && depth === PAGE_UNIT_DEPTH) {
+    const newPage = { pageId: node.id, name: node.name, frames: [] };
+
+    if (parent.pages) {
+      parent.pages.push(newPage);
+    }
+
+    node.children.forEach((child) =>
+      saveFigmaDataAsNestedStructure(child, newPage, depth + 1),
+    );
+  } else if (node.type === "FRAME" && depth === FRAME_UNIT_DEPTH) {
+    const newFrame = { frameId: node.id, name: node.name, nodes: [] };
+
+    if (parent.frames) {
+      parent.frames.push(newFrame);
+    }
+
+    node.children.forEach((child) =>
+      saveFigmaDataAsNestedStructure(child, newFrame, depth + 1),
+    );
+  } else if (depth > FRAME_UNIT_DEPTH) {
+    const newNode = {
+      nodeId: node.id,
+      type: node.type,
+      frameId: currentFrameId,
+    };
+    newNode.property = {};
+
+    const excludedKeys = [
+      "id",
+      "name",
+      "type",
+      "scrollBehavior",
+      "blendMode",
+      "children",
+    ];
+
+    Object.keys(node).forEach((key) => {
+      if (!excludedKeys.includes(key)) {
+        newNode.property[key] = node[key];
+      }
+    });
+
+    if (parent.nodes) {
+      parent.nodes.push(newNode);
+    }
+  }
+
+  return parent;
+}
+
+module.exports = saveFigmaDataAsNestedStructure;


### PR DESCRIPTION
## Fix (이슈 번호)
closes #6

<br />

## 해결하려던 문제를 알려주세요!
사용자가 선택한 버전의 각각의 서브트리를 저장 후 
공통 페이지 리스트를 응답으로 보내야 합니다.

<br />

## 어떻게 해결했나요?
1. **Figma API 연동**: 프로젝트의 버전 데이터를 Figma API를 통해 가져옵니다.
2. **깊이 우선 탐색(DFS) 적용**: 피그마 파일의 JSON 구조를 DFS를 이용해 탐색하며, 
각 Depth와 Type에 따라 데이터를 처리합니다.
3. **데이터베이스 저장 로직 구현**: 탐색된 데이터를 Project 스키마, Page 스키마에 맞게 분류하여 저장합니다. 프레임 이하 단위의 노드들은 Node 스키마에 저장합니다.
4. DB에 해당 결과값이 없다면, Figma API를 Before와 After버전의 서브 트리를 가져와
Before와 After버전의 **서브 트리 평탄화 하여 DB에 저장**했습니다.
5. **두 버전 내 공통 페이지 리스트 구현**: 동일 파일 버전 내 동일한 `pageId`들만 모아 공통 페이지 리스트를 만들어 클라이언트에게 전달하는 로직을 구현했습니다.


<br />

## 우려사항이 있나요?(선택사항)

### 1. 토큰 전달 방식 수정
현재 토큰을 전달하는 방식은 기존에 작성되어 있던 `Figma X Token` 전달 방식을 
사용하고 있습니다. 클라이언트 내 `OAuth 2.0` 로그인 방식 구현 후, 수정이 필요합니다.

### 2. ESLint 함수 선언 순서 에러
![eslint error](https://github.com/Figci/Figci-Server/assets/43771772/29d75c9d-f54a-4274-9916-8445d52f43a4)
lint 검사 시, 함수 선언의 순서에 따라 에러가 발생합니다. 함수선언문이라도 
함수를 실행하기 전에 선언해두어야 합니다. 에러나기 쉬운 케이스라 공유 드립니다!

### 3. MongoDB Skema Design 수정
아래 Attachment에 있는 스키마 디자인 참고 부탁드립니다. 
클라이언트 로직 상 필요한 속성(페이지, 화면 명)을 추가했습니다.

### 4. Controller 내 요청에 따른 응답 로직 작성
`projectController` 내 응답 로직을 따로 분리해두었습니다.

관심사 분리와 가독성 측면에서 분리했는데 예를 들어 현재 저희는 이전, 다음 버전 별 
피그마 파일 데이터를 받아와 공통 페이지를 찾고 전달하는 방식으로 
복잡하고 긴 로직으로 이루어져 있습니다.

그 이유로, `router` 디렉토리 내에서는 Endpoint와 Controller만 연결하는 방식으로 작업했고, 
현 방식이 Approve 되면 동일하게 코드 작성 부탁드립니다.

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 

### 3차 스키마 디자인
<img width="692" alt="3차 스키마 디자인" src="https://github.com/Figci/Figci-Server/assets/43771772/acf2ffe8-ad3e-4402-b981-770bca2b0b1b">

`Frame`, `Page`, `Node`의 이름을 명시해주고, 클라이언트에 데이터 전송 시 
각 데이터의 name 정보가 필요해 `name` 속성들을 추가했습니다. 

[이전 스키마 디자인](https://github.com/Figci/Figci-Server/pull/10#issue-2115474545)

<br />
