### PR TITLE
Feature: diffing Endpoint & diffing로직 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,5 +27,9 @@ module.exports = {
     "no-restricted-syntax": ["error", "LabeledStatement", "WithStatement"],
     "array-callback-return": "off",
     "consistent-return": "off",
+    "no-continue": "off",
+    "no-underscore-dangle": "off",
+    "no-await-in-loop": "off",
+    "no-shadow": "off",
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,7 @@ module.exports = {
     "no-unused-vars": "warn",
     "no-param-reassign": 0,
     "no-restricted-syntax": ["error", "LabeledStatement", "WithStatement"],
+    "array-callback-return": "off",
+    "consistent-return": "off",
   },
 };

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -1,9 +1,10 @@
-/* eslint-disable consistent-return */
 const createHttpError = require("http-errors");
 const Document = require("../models/Document");
+const Result = require("../models/Result");
 
 const comparePages = require("../utils/comparePages");
 const saveFigmaDataAsNestedStructure = require("../utils/saveFigmaDataAsNestedStructure");
+const getDiffing = require("../utils/getDiffing");
 const CONSTANT = require("../constants/constants");
 const ERROR = require("../constants/error");
 
@@ -75,6 +76,7 @@ const getCommonPages = async (req, res, next) => {
 
   const createDocument = async (projectKey, versionId) => {
     const figmaData = await fetchFigmaData(projectKey, versionId);
+
     const document = await saveFigmaDataAsNestedStructure(
       figmaData.document,
       null,
@@ -114,4 +116,114 @@ const getCommonPages = async (req, res, next) => {
   }
 };
 
-module.exports = { getAllVersions, getCommonPages };
+const getStoredDiffingResult = async (
+  projectKey,
+  beforeVersionId,
+  afterVersionId,
+  pageId,
+) => {
+  const storedDiffingResult = await Result.findOne({
+    projectKey,
+    beforeVersionId,
+    afterVersionId,
+    pageId,
+  });
+
+  return storedDiffingResult;
+};
+
+const createDiffingResult = async (
+  projectKey,
+  beforeVersionId,
+  afterVersionId,
+  pageId,
+) => {
+  const getDocument = async (projectKey, versionId) => {
+    const document = await Document.findOne({
+      projectKey,
+      versionId,
+    });
+
+    return document;
+  };
+
+  const beforeDocument = await getDocument(projectKey, beforeVersionId);
+  const afterDocument = await getDocument(projectKey, afterVersionId);
+
+  const beforeFrameList = beforeDocument.pages.get(pageId).frames;
+  const afterFrameList = afterDocument.pages.get(pageId).frames;
+
+  const diffingResult = {
+    projectKey,
+    beforeVersionId,
+    afterVersionId,
+    pageId,
+    frames: new Set(),
+    differences: {},
+  };
+
+  await getDiffing(beforeFrameList, afterFrameList, diffingResult);
+
+  const diffingInstance = await Result.create(diffingResult);
+
+  return diffingInstance;
+};
+
+const getModifiedFrame = async (projectKey, versionId, pageId, frameId) => {
+  const modifiedDocument = await Document.findOne({
+    projectKey,
+    versionId,
+  });
+
+  const modifiedPage = modifiedDocument.pages.get(pageId);
+  const modifiedFrame = modifiedPage.frames.get(frameId);
+
+  return modifiedFrame;
+};
+
+const getDiffingResult = async (req, res, next) => {
+  const { projectId: projectKey, pageId } = req.params;
+  const beforeVersionId = req.query["before-version"];
+  const afterVersionId = req.query["after-version"];
+
+  try {
+    const diffingResult =
+      (await getStoredDiffingResult(
+        projectKey,
+        beforeVersionId,
+        afterVersionId,
+        pageId,
+      )) ||
+      (await createDiffingResult(
+        projectKey,
+        beforeVersionId,
+        afterVersionId,
+        pageId,
+      ));
+
+    const modifiedFrameIdList = diffingResult.frames;
+    diffingResult.frames = [];
+
+    for (const modifiedFrameId of modifiedFrameIdList) {
+      const modifiedFrame = await getModifiedFrame(
+        projectKey,
+        afterVersionId,
+        pageId,
+        modifiedFrameId,
+      );
+
+      diffingResult.frames.push(modifiedFrame);
+    }
+
+    res.status(200).json(diffingResult);
+  } catch (err) {
+    const customError = createHttpError(
+      ERROR.SERVER_ERROR.status,
+      ERROR.SERVER_ERROR.message,
+    );
+
+    next(customError);
+  }
+};
+
+module.exports = { getAllVersions, getCommonPages, getDiffingResult };

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -10,12 +10,12 @@ const CONSTANT = require("../constants/constants");
 const ERROR = require("../constants/error");
 
 const getAllVersions = async (req, res, next) => {
-  const { projectId } = req.params;
+  const { projectId: projectKey } = req.params;
   const accessToken = req.headers.authorization;
 
   try {
     const getVersions = await fetch(
-      `https://api.figma.com/v1/files/${projectId}/versions`,
+      `https://api.figma.com/v1/files/${projectKey}/versions`,
       {
         method: "GET",
         headers: {
@@ -47,10 +47,10 @@ const getAllVersions = async (req, res, next) => {
 };
 
 const getCommonPages = async (req, res, next) => {
-  const { projectId } = req.params;
+  const { projectId: projectKey } = req.params;
   const accessToken = req.headers.authorization;
-  const beforeVersion = req.query["before-version"];
-  const afterVersion = req.query["after-version"];
+  const beforeVersionId = req.query["before-version"];
+  const afterVersionId = req.query["after-version"];
 
   const fetchFigmaData = async (projectKey, versionId) => {
     const figmaUrl = `https://api.figma.com/v1/files/${projectKey}?version=${versionId}`;
@@ -85,12 +85,12 @@ const getCommonPages = async (req, res, next) => {
 
   try {
     const beforeDocument =
-      (await getDocument(projectId, beforeVersion)) ||
-      (await createDocument(projectId, beforeVersion));
+      (await getDocument(projectKey, beforeVersionId)) ||
+      (await createDocument(projectKey, beforeVersionId));
 
     const afterDocument =
-      (await getDocument(projectId, afterVersion)) ||
-      (await createDocument(projectId, afterVersion));
+      (await getDocument(projectKey, afterVersionId)) ||
+      (await createDocument(projectKey, afterVersionId));
 
     const matchedPages = comparePages(
       beforeDocument.pages,

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -5,6 +5,7 @@ const Result = require("../models/Result");
 const comparePages = require("../utils/comparePages");
 const saveFigmaDataAsNestedStructure = require("../utils/saveFigmaDataAsNestedStructure");
 const getDiffing = require("../utils/getDiffing");
+const getDocument = require("../utils/getDocument");
 const CONSTANT = require("../constants/constants");
 const ERROR = require("../constants/error");
 
@@ -63,15 +64,6 @@ const getCommonPages = async (req, res, next) => {
     const projectVersionSubtree = await responseJson.json();
 
     return projectVersionSubtree;
-  };
-
-  const getDocument = async (projectKey, versionId) => {
-    const document = await Document.findOne({
-      projectKey,
-      versionId,
-    });
-
-    return document;
   };
 
   const createDocument = async (projectKey, versionId) => {
@@ -138,15 +130,6 @@ const createDiffingResult = async (
   afterVersionId,
   pageId,
 ) => {
-  const getDocument = async (projectKey, versionId) => {
-    const document = await Document.findOne({
-      projectKey,
-      versionId,
-    });
-
-    return document;
-  };
-
   const beforeDocument = await getDocument(projectKey, beforeVersionId);
   const afterDocument = await getDocument(projectKey, afterVersionId);
 

--- a/src/models/Document.js
+++ b/src/models/Document.js
@@ -5,26 +5,35 @@ const { Schema } = mongoose;
 const NodeSchema = new Schema({
   nodeId: { type: String, require: true },
   type: { type: String, require: true },
-  children: { type: Array, require: true },
+  children: { type: Object, require: true },
   property: { type: Object, require: true },
 });
 
 const FrameSchema = new Schema({
   frameId: { type: String, require: true },
   name: { type: String, require: true },
-  nodes: [NodeSchema],
+  nodes: {
+    type: Map,
+    of: NodeSchema,
+  },
 });
 
 const PageSchema = new Schema({
   pageId: { type: String, require: true },
   name: { type: String, require: true },
-  frames: [FrameSchema],
+  frames: {
+    type: Map,
+    of: FrameSchema,
+  },
 });
 
 const DocumentSchema = new Schema({
   projectKey: { type: String, require: true },
   versionId: { type: String, require: true },
-  pages: [PageSchema],
+  pages: {
+    type: Map,
+    of: PageSchema,
+  },
 });
 
 module.exports = mongoose.model("Document", DocumentSchema);

--- a/src/models/Result.js
+++ b/src/models/Result.js
@@ -3,7 +3,9 @@ const mongoose = require("mongoose");
 const { Schema } = mongoose;
 
 const DifferenceSchema = new Schema({
+  type: { type: String, require: true },
   nodeId: { type: String, require: true },
+  frameId: { type: String, require: true },
   differenceInformation: { type: Object, require: true },
   position: { type: Object, require: true },
 });
@@ -13,19 +15,11 @@ const ResultSchema = new Schema({
   beforeVersionId: { type: String, require: true },
   afterVersionId: { type: String, require: true },
   pageId: { type: String, require: true },
-  frames: [{ type: mongoose.Schema.Types.ObjectId, ref: "Document" }],
-  differences: [DifferenceSchema],
-});
-
-ResultSchema.pre(/^find/, function (next) {
-  this.populate({
-    path: "frames",
-    populate: {
-      path: "pages.frames",
-    },
-  });
-
-  next();
+  frames: { type: Array, require: true },
+  differences: {
+    type: Map,
+    of: DifferenceSchema,
+  },
 });
 
 module.exports = mongoose.model("Result", ResultSchema);

--- a/src/routers/projects.js
+++ b/src/routers/projects.js
@@ -6,5 +6,6 @@ const router = express.Router();
 
 router.get("/:projectId/versions", projectController.getAllVersions);
 router.get("/:projectId/pages", projectController.getCommonPages);
+router.get("/:projectId/pages/:pageId/", projectController.getDiffingResult);
 
 module.exports = router;

--- a/src/utils/comparePages.js
+++ b/src/utils/comparePages.js
@@ -1,17 +1,17 @@
+/* eslint-disable-next-line array-callback-return */
+
 function comparePages(beforePages, afterPages) {
-  const matchedPages = [];
+  const beforePageIdList = Array.from(beforePages.keys());
+  const afterPageIdList = Array.from(afterPages.keys());
 
-  beforePages.forEach((beforePage) => {
-    const matchedPage = afterPages.find(
-      (afterPage) => afterPage.pageId === beforePage.pageId,
-    );
-
-    if (matchedPage) {
-      matchedPages.push(matchedPage);
+  return beforePageIdList.map((beforePageId) => {
+    if (afterPageIdList.includes(beforePageId)) {
+      return {
+        pageId: beforePageId,
+        pageName: beforePages.get(beforePageId).name,
+      };
     }
   });
-
-  return matchedPages;
 }
 
 module.exports = comparePages;

--- a/src/utils/comparePages.js
+++ b/src/utils/comparePages.js
@@ -1,6 +1,4 @@
-/* eslint-disable-next-line array-callback-return */
-
-function comparePages(beforePages, afterPages) {
+const comparePages = (beforePages, afterPages) => {
   const beforePageIdList = Array.from(beforePages.keys());
   const afterPageIdList = Array.from(afterPages.keys());
 
@@ -12,6 +10,6 @@ function comparePages(beforePages, afterPages) {
       };
     }
   });
-}
+};
 
 module.exports = comparePages;

--- a/src/utils/getDiffing.js
+++ b/src/utils/getDiffing.js
@@ -1,0 +1,103 @@
+const isOwnProperty = (object, property) => {
+  return Object.prototype.hasOwnProperty.call(object, property);
+};
+
+const diffProperties = (
+  beforeProperties,
+  afterProperties,
+  frameId,
+  nodeId,
+  position,
+  diffingResult,
+  path,
+  depth,
+) => {
+  if (depth === 0) {
+    afterProperties = afterProperties._doc;
+  }
+
+  for (const property in afterProperties) {
+    if (isOwnProperty(afterProperties, property)) {
+      const beforeValue = beforeProperties?.[property];
+      const afterValue = afterProperties[property];
+
+      if (typeof afterValue === "object") {
+        diffProperties(
+          beforeValue,
+          afterValue,
+          frameId,
+          nodeId,
+          position,
+          diffingResult,
+          `${path}.${property}`,
+          depth + 1,
+        );
+
+        continue;
+      }
+
+      if (beforeValue !== afterValue) {
+        if (!diffingResult.differences[nodeId]) {
+          diffingResult.differences[nodeId] = {
+            type: "MODIFIED",
+            nodeId,
+            frameId,
+            differenceInformation: {},
+            position,
+          };
+        }
+
+        const propertyRoute = `${path}.${property}`.slice(10);
+
+        diffingResult.differences[nodeId].differenceInformation[propertyRoute] =
+          `${beforeValue} => ${afterValue}`;
+
+        diffingResult.frames.add(frameId);
+      }
+    }
+  }
+};
+
+const getDiffing = async (beforeFrameList, afterFrameList, diffingResult) => {
+  for (const [afterFrameId, afterFrame] of afterFrameList) {
+    const beforeFrame = beforeFrameList.get(afterFrameId);
+
+    if (!beforeFrame) {
+      diffingResult.frames.add(afterFrameId);
+
+      continue;
+    }
+
+    for (const [afterNodeId, afterNode] of afterFrame.nodes) {
+      const beforeNode = beforeFrame.nodes.get(afterNodeId);
+      const nodePosition = afterNode.property.absoluteRenderBounds;
+
+      if (!beforeNode) {
+        diffingResult.differences[afterNodeId] = {
+          type: "NEW",
+          nodeId: afterNodeId,
+          frameId: afterFrameId,
+          differenceInformation: {},
+          position: nodePosition,
+        };
+
+        continue;
+      }
+
+      diffProperties(
+        beforeNode,
+        afterNode,
+        afterFrameId,
+        afterNodeId,
+        nodePosition,
+        diffingResult,
+        "",
+        0,
+      );
+    }
+  }
+
+  diffingResult.frames = Array.from(diffingResult.frames);
+};
+
+module.exports = getDiffing;

--- a/src/utils/getDocument.js
+++ b/src/utils/getDocument.js
@@ -1,0 +1,12 @@
+const Document = require("../models/Document");
+
+const getDocument = async (projectKey, versionId) => {
+  const document = await Document.findOne({
+    projectKey,
+    versionId,
+  });
+
+  return document;
+};
+
+module.exports = getDocument;

--- a/src/utils/saveFigmaDataAsNestedStructure.js
+++ b/src/utils/saveFigmaDataAsNestedStructure.js
@@ -7,7 +7,7 @@ const saveFigmaDataAsNestedStructure = async (
   currentFrameId = "",
 ) => {
   if (depth === 0 && node.type === "DOCUMENT") {
-    parent = { pages: [] };
+    parent = { pages: {} };
   }
 
   if (node.children) {
@@ -17,20 +17,28 @@ const saveFigmaDataAsNestedStructure = async (
   }
 
   if (node.type === "CANVAS" && depth === CONSTANT.PAGE_NODE_DEPTH) {
-    const newPage = { pageId: node.id, name: node.name, frames: [] };
+    const newPage = {
+      pageId: node.id,
+      name: node.name,
+      frames: {},
+    };
 
     if (parent.pages) {
-      parent.pages.push(newPage);
+      parent.pages[newPage.pageId] = newPage;
     }
 
     node.children.forEach((child) =>
       saveFigmaDataAsNestedStructure(child, newPage, depth + 1),
     );
   } else if (node.type === "FRAME" && depth === CONSTANT.FRAME_NODE_DEPTH) {
-    const newFrame = { frameId: node.id, name: node.name, nodes: [] };
+    const newFrame = {
+      frameId: node.id,
+      name: node.name,
+      nodes: {},
+    };
 
     if (parent.frames) {
-      parent.frames.push(newFrame);
+      parent.frames[newFrame.frameId] = newFrame;
     }
 
     node.children.forEach((child) =>
@@ -41,8 +49,8 @@ const saveFigmaDataAsNestedStructure = async (
       nodeId: node.id,
       type: node.type,
       frameId: currentFrameId,
+      property: {},
     };
-    newNode.property = {};
 
     const excludedKeys = [
       "id",
@@ -62,7 +70,7 @@ const saveFigmaDataAsNestedStructure = async (
     }
 
     if (parent.nodes) {
-      parent.nodes.push(newNode);
+      parent.nodes[newNode.nodeId] = newNode;
     }
   }
 


### PR DESCRIPTION
## Fix (이슈 번호)
closes #3 

<br />

## 해결하려던 문제를 알려주세요!
두개의 버전의 각각 공통의 ID를 가진 page를 파싱하여 diffing로직을 구현했습니다.

<br/>

### 마주했던 문제점
- **_diffing중 시간복잡도 증가_**
→ 기존에 `subDocument`들을 `Array`로 type을 지정해 두었지만, diffing로직을 구현하기에는 부적합 하다고 판단이 들었습니다.

2. `Difference` 스키마를 `Result`스키마의 `subDocument`로 설정할 필요가 있을까?
→ 서브트리를 저장하는 Document스키마와는 달리 difference스키마는 따로 key를 통해서 값을 가져올 일이 없기 때문에 subDocument구조를 해제할까 고민했습니다.

<br />

## 어떻게 해결했나요?
- **_스키마 타입을 Array에서 Map으로 수정_**
diffing은 두개의 페이지 트리가 depth가 달라지는 경우가 생겨서 동시에 두개의 트리를 순회하기에 부적합 했습니다.
따라서 저희는 프레임 이하 단위의 노드들을 평탄화 하여서 배열에 담은 뒤, 두 페이지의 공통된 노드들을 찾아서 비교를 하려고 하였으나,
`afterVersion`에 있는 노드를 `nodeId`값으로 `beforeVersion`에서 찾아내려면 전체 노드를 순회하면서 id값을 비교해야 했습니다.
이는 너무 시간복잡도가 비효율적이라고 판단이 되어서 nodeId값을 key로 갖고, 해당 노드 내용을 value로 매핑하고자 생각해본 결과
`Map`이 적합하다고 판단되어 `Map` type으로 `subDocument`를 수정 하였습니다.

- **_기존안 유지_**
`Difference`스키마는 데이터 안정성을 위하여 지금처럼 따로 스키마로 유지하기로 팀원들과 협의 후 결정했습니다.

<br />

## 우려사항이 있나요?(선택사항)
1. **_`eslint` 설정을 변경했습니다._**
2. **`_Difference`스키마가 Result스키마의 `subDocument`로 작성이 되어져있기 때문에 `diffingResult`를 클라이언트 측에서 전달 받을 시 `ObjectId`가 포함되어져 있습니다._**
3. **_기존에 통일되어져 있지 않았던 변수명을 통일했습니다._**
`projectId` → `projectKey`
`beforeVersion` → `beforeVersionId`
`afterVersion` → `afterVersionId`
4. **_`getDocument`를 모듈화 하였습니다._**
기존에 `getCommonPage` controller 내부에 정의되어져 있던 `getDocumnet`함수를 `diffing` controller에서도 사용하기 위해서
`utils` 디렉토리 내부로 모듈화 하였습니다.
<br />

## 잠깐! 확인해보셨나요?

- [x]  셀프 리뷰는 완료하셨나요?
- [x]  가장 최신 브랜치를 pull했나요?
- [x]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [x]  코드 컨벤션을 모두 지켰나요?
- [x]  적절한 라벨이 있나요?
- [x]  assignee가 있나요?

<br />

## Attachment(선택사항) 
<img width="975" alt="image" src="https://github.com/Figci/Figci-Server/assets/48385389/fe5f4655-273f-4068-8bd9-13c1cc12dae0">
→ 데이터 전달 형식