### PR TITLE
Refactor: response구조 변경

### DIFF
--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -35,7 +35,11 @@ const getAllVersions = async (req, res, next) => {
       });
     }
 
-    res.status(200).json(responseJson);
+    res.status(200).json({
+      result: "success",
+      status: 200,
+      content: versions,
+    });
   } catch (err) {
     const customError = createHttpError(
       ERROR.SERVER_ERROR.status,
@@ -97,7 +101,11 @@ const getCommonPages = async (req, res, next) => {
       afterDocument.pages,
     );
 
-    res.status(200).json(matchedPages);
+    res.status(200).json({
+      result: "success",
+      status: 200,
+      content: matchedPages,
+    });
   } catch (err) {
     const customError = createHttpError(
       ERROR.SERVER_ERROR.status,
@@ -198,7 +206,11 @@ const getDiffingResult = async (req, res, next) => {
       diffingResult.frames.push(modifiedFrame);
     }
 
-    res.status(200).json(diffingResult);
+    res.status(200).json({
+      result: "success",
+      status: 200,
+      content: diffingResult,
+    });
   } catch (err) {
     const customError = createHttpError(
       ERROR.SERVER_ERROR.status,


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

## 해결하려던 문제를 알려주세요!
클라이언트 측에서 응답을 받을 때 효율적인 에러핸들링을 위해서 구조를 통일했습니다.

<br />

## 어떻게 해결했나요?
커스텀 에러응답과 동일한 구조를 가져감으로써 클라이언트에서 해당 응답에 대한 성공여부를 쉽게 알 수 있습니다.

<br />

## 우려사항이 있나요?(선택사항)
```js
router.get("/:projectId/versions", projectController.getAllVersions);
```
에서 기존에 `versions`만 따로 뽑아서 사용을 하고 있었기에, 서버측에서 보내 줄 때 `versions`만 보내도록 로직을 수정했습니다.

<br />

## 잠깐! 확인해보셨나요?

- [x]  셀프 리뷰는 완료하셨나요?
- [x]  가장 최신 브랜치를 pull했나요?
- [x]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [x]  코드 컨벤션을 모두 지켰나요?
- [x]  적절한 라벨이 있나요?
- [x]  assignee가 있나요?

<br />

## Attachment(선택사항) 
> 리뷰어의 이해를 돕기 위한 모든 이미지, GIF, 링크 등을 첨부해주세요!
> 이번 PR 내 로직, 동작의 이해를 돕는 GIF 파일,
> FRONT 동작 내 스크린샷 등

<br />
