### PR TITLE
Feat: diffingResult응답 분기처리

### DIFF
--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -193,13 +193,11 @@ const getDiffingResult = async (req, res, next) => {
       ));
 
     if (!diffingResult.frames.length) {
-      res.status(204).json({
+      return res.status(204).json({
         result: "error",
         status: 204,
         message: "해당 페이지는 차이점이 없어요.",
       });
-
-      return;
     }
 
     const modifiedFrameIdList = diffingResult.frames;

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -28,9 +28,9 @@ const getAllVersions = async (req, res, next) => {
     const { versions } = responseJson;
 
     if (versions.length < CONSTANT.NO_PREVIOUS_VERSIONS) {
-      return res.json({
+      return res.status(204).json({
         result: "error",
-        status: 502,
+        status: 204,
         message: "해당 파일은 비교할 수 있는 버전이 없어요.",
       });
     }
@@ -191,6 +191,16 @@ const getDiffingResult = async (req, res, next) => {
         afterVersionId,
         pageId,
       ));
+
+    if (!diffingResult.frames.length) {
+      res.status(204).json({
+        result: "error",
+        status: 204,
+        message: "해당 페이지는 차이점이 없어요.",
+      });
+
+      return;
+    }
 
     const modifiedFrameIdList = diffingResult.frames;
     diffingResult.frames = [];


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

## 해결하려던 문제를 알려주세요!
diffngResult 엔드포인트에서 비교할 페이지가 없는 경우 `204` code와 함께 비교할 페이지가 없다는 응답을 보내는 것을 분기처리 했습니다.

<br />

## 어떻게 해결했나요?
if문을 사용하여 비교결과에 frames의 길이가 0이라면 해당 응답을 보내도록 분기처리 했습니다.

<br />

## 우려사항이 있나요?(선택사항)
특이사항 없습니다!

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 
