### PR TITLE
Fix: 피그마 JSON 데이터 BFS 알고리즘 변경 및 Frame 속성 추가

### DIFF
--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -4,6 +4,14 @@ const CONSTANTS = {
   COMPARABLE_VERSION_NUMBER: 2,
   PAGE_NODE_DEPTH: 1,
   FRAME_NODE_DEPTH: 2,
+  EXCLUDED_KEYS: {
+    id: true,
+    name: true,
+    type: true,
+    scrollBehavior: true,
+    blendMode: true,
+    children: true,
+  },
 };
 
 module.exports = CONSTANTS;

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -2,7 +2,7 @@ const createHttpError = require("http-errors");
 const Document = require("../models/Document");
 
 const comparePages = require("../utils/comparePages");
-const saveFigmaDataAsNestedStructure = require("../utils/saveFigmaDataAsNestedStructure");
+const flattenFigmaSubtree = require("../utils/flattenFigmaSubtree");
 const getDiffing = require("../utils/getDiffing");
 const getDocument = require("../utils/getDocument");
 const CONSTANT = require("../constants/constants");
@@ -72,11 +72,7 @@ const getCommonPages = async (req, res, next) => {
   const createDocument = async (projectKey, versionId) => {
     const figmaData = await fetchFigmaData(projectKey, versionId);
 
-    const document = await saveFigmaDataAsNestedStructure(
-      figmaData.document,
-      null,
-      0,
-    );
+    const document = await flattenFigmaSubtree(figmaData.document);
 
     document.projectKey = projectKey;
     document.versionId = versionId;

--- a/src/models/Document.js
+++ b/src/models/Document.js
@@ -16,6 +16,7 @@ const FrameSchema = new Schema({
     type: Map,
     of: NodeSchema,
   },
+  property: { type: Object, require: true },
 });
 
 const PageSchema = new Schema({

--- a/src/models/Document.js
+++ b/src/models/Document.js
@@ -12,11 +12,11 @@ const NodeSchema = new Schema({
 const FrameSchema = new Schema({
   frameId: { type: String, require: true },
   name: { type: String, require: true },
+  property: { type: Object, require: true },
   nodes: {
     type: Map,
     of: NodeSchema,
   },
-  property: { type: Object, require: true },
 });
 
 const PageSchema = new Schema({

--- a/src/utils/flattenFigmaSubtree.js
+++ b/src/utils/flattenFigmaSubtree.js
@@ -1,6 +1,6 @@
 const CONSTANT = require("../constants/constants");
 
-const saveFigmaDataAsNestedStructure = (root) => {
+const flattenFigmaSubtree = (root) => {
   if (!root || root.type !== "DOCUMENT") {
     return null;
   }
@@ -31,17 +31,8 @@ const saveFigmaDataAsNestedStructure = (root) => {
         property: {},
       };
 
-      const excludedKeys = [
-        "id",
-        "name",
-        "type",
-        "scrollBehavior",
-        "blendMode",
-        "children",
-      ];
-
       for (const key in node) {
-        if (!excludedKeys.includes(key)) {
+        if (!CONSTANT.EXCLUDED_KEYS[key]) {
           newFrame.property[key] = node[key];
         }
       }
@@ -59,18 +50,9 @@ const saveFigmaDataAsNestedStructure = (root) => {
         property: {},
       };
 
-      const excludedKeys = [
-        "id",
-        "name",
-        "type",
-        "scrollBehavior",
-        "blendMode",
-        "children",
-      ];
-
       for (const key in node) {
         if (Object.prototype.hasOwnProperty.call(node, key)) {
-          if (!excludedKeys.includes(key)) {
+          if (!CONSTANT.EXCLUDED_KEYS[key]) {
             newNode.property[key] = node[key];
           }
         }
@@ -96,4 +78,4 @@ const saveFigmaDataAsNestedStructure = (root) => {
   return structure;
 };
 
-module.exports = saveFigmaDataAsNestedStructure;
+module.exports = flattenFigmaSubtree;


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

## 해결하려던 문제를 알려주세요!
Figma 레이아웃 순서와 Canvas 렌더링 순서를 맞추고, Frame 속성(property)가 없어
렌더링되지 않는 오류 해결을 위해 BFS 방식으로 알고리즘을 수정했습니다!

<br />

## 어떻게 해결했나요?
기존 피그마 JSON Data 평탄화 방식을 위한 알고리즘을 `DFS` -> `BFS`로 바꿨습니다.
추가로 Canvas 내 렌더링 시 `Frame property`가 없어 Frame 색상이나 스타일 반영이 어려워
데이터에 추가되는 조건을 넣어두었습니다.

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 

> 리뷰어의 이해를 돕기 위한 모든 이미지, GIF, 링크 등을 첨부해주세요!
> 이번 PR 내 로직, 동작의 이해를 돕는 GIF 파일,
> FRONT 동작 내 스크린샷 등

<br />
