### PR TITLE
Refactor: InvalidToken response 대응

### DIFF
--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -24,6 +24,15 @@ const getAllVersions = async (req, res, next) => {
     );
 
     const responseJson = await getVersions.json();
+
+    if (responseJson.status === 403) {
+      return res.status(200).json({
+        result: "error",
+        status: 403,
+        message: "Invalid Token",
+      });
+    }
+
     const { versions } = responseJson;
 
     if (versions.length < CONSTANT.COMPARABLE_VERSION_NUMBER) {

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -81,7 +81,7 @@ const getCommonPages = async (req, res, next) => {
   const createDocument = async (projectKey, versionId) => {
     const figmaData = await fetchFigmaData(projectKey, versionId);
 
-    const document = await flattenFigmaSubtree(figmaData.document);
+    const document = flattenFigmaSubtree(figmaData.document);
 
     document.projectKey = projectKey;
     document.versionId = versionId;

--- a/src/loaders/error.js
+++ b/src/loaders/error.js
@@ -5,7 +5,7 @@ const errorLoader = (app) => {
     next(createError(404));
   });
 
-  app.use((err, req, res) => {
+  app.use((err, req, res, next) => {
     res.locals.message = err.message;
     res.locals.error = req.app.get("env") === "development" ? err : {};
 

--- a/src/utils/getDiffing.js
+++ b/src/utils/getDiffing.js
@@ -71,7 +71,7 @@ const getDiffing = async (beforeFrameList, afterFrameList, diffingResult) => {
 
     for (const [afterNodeId, afterNode] of afterFrame.nodes) {
       const beforeNode = beforeFrame.nodes.get(afterNodeId);
-      const nodePosition = afterNode.property.absoluteRenderBounds;
+      const nodePosition = afterNode.property.absoluteBoundingBox;
 
       if (!beforeNode) {
         diffingResult.differences[afterNodeId] = {


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

## 해결하려던 문제를 알려주세요!
InvalidToken은 error를 발생시키지 않고, InvalidToken이라는 응답을 보내주기 때문에
해당 API response에 대한 대응필요

<br />

## 어떻게 해결했나요?
Figma API에서 status코드가 `403`인 경우는 `invalidToken`밖에 없다는 것을 확인 후
`if`문을 이용해서 분기처리를 하였습니다.

<br />

## 우려사항이 있나요?(선택사항)
1. difference인스턴스의 `position`필드 값이 기존 `absoluteRenderBounds`에서 `absoluteBoundingBox`로 수정되었습니다.
2. 에러처리 미들웨어에 인자 `next`를 추가했습니다.
3. `flattenFigmaSubtree`이 `async`에서 `sync`로 변경됨에 따라서 `await`를 삭제했습니다.

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 

> 리뷰어의 이해를 돕기 위한 모든 이미지, GIF, 링크 등을 첨부해주세요!
> 이번 PR 내 로직, 동작의 이해를 돕는 GIF 파일,
> FRONT 동작 내 스크린샷 등