### PR TITLE
HotFix: diffing시 widget타입을 만나면 에러 발생 수정

### DIFF
--- a/src/utils/getDiffing.js
+++ b/src/utils/getDiffing.js
@@ -73,10 +73,9 @@ const getDiffing = async (beforeFrameList, afterFrameList, diffingResult) => {
       const beforeNode = beforeFrame.nodes.get(afterNodeId);
 
       if (!afterNode.property) {
-        console.log(afterNode);
-
         continue;
       }
+
       const nodePosition = afterNode.property.absoluteBoundingBox;
 
       if (!beforeNode) {

--- a/src/utils/getDiffing.js
+++ b/src/utils/getDiffing.js
@@ -71,6 +71,12 @@ const getDiffing = async (beforeFrameList, afterFrameList, diffingResult) => {
 
     for (const [afterNodeId, afterNode] of afterFrame.nodes) {
       const beforeNode = beforeFrame.nodes.get(afterNodeId);
+
+      if (!afterNode.property) {
+        console.log(afterNode);
+
+        continue;
+      }
       const nodePosition = afterNode.property.absoluteBoundingBox;
 
       if (!beforeNode) {


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

기존에 diffing을 할 때  position값을 각 노드의 `absoluteBoundingBox`에서 가져오는데
`WIDGET`타입인 노드의 경우, 해당 값을 갖고있지 않아서 에러가 발생하고 있었습니다.
<br/>
<img width="281" alt="image" src="https://github.com/Figci/Figci-Server/assets/48385389/b34117a4-5c2e-43b9-84c9-f177ae8d919f">

→ `WIDGET`타입의 경우 본인은 어떠한 스타일 `property`도 갖지 않고, 내부 `childern`들로 구성됩니다.
서브트리를 평탄화 하는 과정에 스타일 관련 `property`들을 property라는 객체에 모아놓게 되는데, 스타일 관련 `property`가 존재하지 않다보니 `.property`가 존재하지 않아서 에러가 발생하고 있었습니다.

![image](https://github.com/Figci/Figci-Server/assets/48385389/eda3e0fc-16d1-4622-88db-98869907c839)


<br />

## 어떻게 해결했나요?
비교하려는 노드의 `.property`가 존재하지 않을 경우, `continue`처리를 해줌으로써 내부 노드로 들어갈 수 있게 처리하였습니다.

<br />

## 우려사항이 있나요?(선택사항)
특이사항 없습니다.

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 

