### PR TITLE
!HOTFIX: newPage에러 수정

### DIFF
--- a/src/utils/comparePages.js
+++ b/src/utils/comparePages.js
@@ -1,15 +1,18 @@
 const comparePages = (beforePages, afterPages) => {
-  const beforePageIdList = Array.from(beforePages.keys());
   const afterPageIdList = Array.from(afterPages.keys());
 
-  return beforePageIdList.map((beforePageId) => {
-    if (afterPageIdList.includes(beforePageId)) {
-      return {
-        pageId: beforePageId,
-        pageName: beforePages.get(beforePageId).name,
-      };
+  const commonPageList = [];
+
+  for (const afterPageId of afterPageIdList) {
+    if (beforePages.get(afterPageId)) {
+      commonPageList.push({
+        pageId: afterPageId,
+        pageName: afterPages.get(afterPageId).name,
+      });
     }
-  });
+  }
+
+  return commonPageList;
 };
 
 module.exports = comparePages;


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

## 해결하려던 문제를 알려주세요!
기존에 beforeVersion을 기준으로 공통페이지를 뽑아내고 있어서, 페이지가 삭제되면
beforeVersion에는 존재하지만, afterVersion에는 존재하지 않아서 공통페이지 list에 null이 추가되어져서 오는 에러가 발생하였습니다.

<br />

## 어떻게 해결했나요?
이에따라서, 공통페이지를 추출 하는 로직을 `afterVersion`을 기준으로 추출하도록 수정 하였고,
이때 기존에 `map`을 통해서 공통페이지 list를 만들다 보니, `afterVersion`에는 존재하는 페이지지만, `beforeVersion`에는 존자하지 않을 시, `undefined`가 공통페이지 리스트에 추가되었습니다.

따라서 순수 "공통페이지" 들만 결과값에 넣어주기 위해서,
공통페이지 리스트를 만들때 `map`을 사용하던 로직을 `for...of`문으로 수정하였습니다.

<br />

## 우려사항이 있나요?(선택사항)
그 외 특이사항 없습니다.

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />
