### PR TITLE
Hotfix: 사이즈 에러 케이스 분기 처리 추가

### DIFF
--- a/src/constants/error.js
+++ b/src/constants/error.js
@@ -15,6 +15,10 @@ const ERROR_PATTERNS = {
     status: 500,
     message: "Internal Server Error",
   },
+  SIZE_ERROR: {
+    status: 500,
+    message: "Can't access Figma info; file too large.🥲",
+  },
 };
 
 module.exports = ERROR_PATTERNS;

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -118,6 +118,10 @@ const getCommonPages = async (req, res, next) => {
       ERROR.SERVER_ERROR.message,
     );
 
+    if (err.code === "ERR_OUT_OF_RANGE") {
+      customError.message = ERROR.SIZE_ERROR.message;
+    }
+
     next(customError);
   }
 };


### PR DESCRIPTION
## Fix (이슈 번호)
none

<br />

## 해결하려던 문제를 알려주세요!
사용자에게 직관적인 에러 메세지를 전달하기 위해서 피그마 JSON 데이터가 클 경우 에러 분기 처리를 해야 했습니다.

<br />

## 어떻게 해결했나요?
에러 코드가 "ERR_OUT_OF_RANGE"일 경우 분기 처리 해줬습니다.

```javascript
 if (err.code === "ERR_OUT_OF_RANGE") {
      customError.message = ERROR.SIZE_ERROR.message;
  }
``` 

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 
### 사이즈 에러의 경우
https://github.com/Figci/Figci-Server/assets/43771772/2ae1692a-b48e-42f0-a6c2-85ff364a8dee

<br />
